### PR TITLE
Added jsx-a11y setting

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,13 @@ module.exports = {
         specialLink: ["to"]
       }
     ],
+    "jsx-a11y/label-has-for": [
+      2,
+      {
+        "required": {
+        "some": [ "nesting", "id" ]
+      }
+    }],
     "no-underscore-dangle": 0,
     "no-debugger": 0,
     "no-console": 0,


### PR DESCRIPTION
This allows label elements which don't wrap their corresponding input element if they have a valid `for` attribute which refs the input `id`

more here - https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/302

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/eslint-config/1)
<!-- Reviewable:end -->
